### PR TITLE
Set the page correctly based on the plugin type

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -45,11 +45,28 @@ module.exports = function (config) {
 
 		render(pathname).then(function(result) {
 			var dt = config.doctype || doctype;
-			var statusCode = result.state.attr("statusCode");
-			res.status(statusCode || 200);
-			res.send(dt + '\n' + result.html);
+			var statusCode = result.state.attr("statusCode") || 200;
+
+      var state = result.state;
+      var AppViewModel = state.constructor;
+      if(is300Status(statusCode) &&
+        AppViewModel.pluginPages[state.attr("page")]) {
+        var redirectUrl = can.route.url({
+          page: state.attr("page"),
+          package: state.attr("package")
+        });
+
+        res.redirect(statusCode, redirectUrl);
+      } else {
+			  res.status(statusCode);
+			  res.send(dt + '\n' + result.html);
+      }
 		});
 	});
 
 	return app;
 };
+
+function is300Status(statusCode) {
+  return statusCode >= 300 && statusCode < 400;
+}

--- a/src/app.js
+++ b/src/app.js
@@ -6,12 +6,20 @@ var pages = [
   "home",
   "search",
   "components",
+  "plugins",
+  "attributes",
   "how-to",
   "register"
 ].reduce(function(pages, page){
   pages[page] = true;
   return pages;
 }, {});
+
+var pluginPages = {
+  "components": true,
+  "attributes": true,
+  "plugins": true
+};
 
 var AppViewModel = AppMap.extend({
   define: {
@@ -44,7 +52,13 @@ var AppViewModel = AppMap.extend({
     },
     wideMode: {
       get: function(){
-        return this.attr("page") === "components";
+        return this.attr("isPluginPage");
+      }
+    },
+    isPluginPage: {
+      get: function(){
+        var page = this.attr("page");
+        return !!pluginPages[page];
       }
     },
     statusCode: {
@@ -59,5 +73,7 @@ var AppViewModel = AppMap.extend({
     }
   }
 });
+
+AppViewModel.pluginPages = pluginPages;
 
 module.exports = AppViewModel;

--- a/src/component/component.component
+++ b/src/component/component.component
@@ -71,9 +71,6 @@
         packageName: {
           type: "string"
         },
-        get: function(){
-
-        },
         component: {
           value: null
         },
@@ -98,12 +95,32 @@
     var requestAnimationFrame = require("canrocks/raf");
 
     exports.componentChange = function(){
+      this.checkType();
+
+      //Highlighting
       var element = this.element;
       requestAnimationFrame(function(){
         hl.highlightChildren(element);
       });
 
       this.setTitle();
+    };
+
+    // Verify that we are on a correct page and if not set the status code
+    // appropriately.
+    exports.checkType = function(){
+      var viewModel = this.viewModel;
+      var component = viewModel.attr("component");
+      var root = viewModel.attr("@root");
+      var page = root.attr("page");
+      var correctPage = component.attr("type") + "s";
+      if(correctPage !== page) {
+        root.attr({
+          page: correctPage,
+          statusCode: 301
+        });
+
+      }
     };
 
     exports["{viewModel} component"] = "componentChange";

--- a/src/component/component_test.js
+++ b/src/component/component_test.js
@@ -1,9 +1,15 @@
 var QUnit = require("steal-qunit");
 var ViewModel = require("./component.component!").ViewModel;
+var State = require("canrocks/app");
 require("canrocks/models/fixtures/");
+var $ = require("jquery");
+var F = require("funcunit");
+var stache = require("can/view/stache/");
+
+F.attach(QUnit);
 
 // ViewModel unit tests
-QUnit.module('component-page email/gravatar', {
+QUnit.module('<component-page> email/gravatar', {
   setup: function(){
     this.vm = new ViewModel({
       packageName: "testPackage",
@@ -27,4 +33,48 @@ QUnit.test("Gets the maintainer's gravatar", function(){
   var expected = "http://www.gravatar.com/avatar/4394f414f0d4a043ad5e8fa261fa2953?r=g&s=50";
   var maintainers = vm.attr("maintainers");
   QUnit.equal(maintainers.attr(0).attr("gravatarUrl"), expected, "got the correct gravatar url");
+});
+
+QUnit.module("<component-page> redirection", {
+  setup: function(){
+    this.state = new State({
+      page: "components",
+      package: "can-interrupt"
+    });
+    var template = stache("<component-page package-name='{package}'></component-page>");
+    $("#qunit-test-area").html(template(this.state));
+  },
+  teardown: function(){
+    $("#qunit-test-area").empty();
+  }
+});
+
+QUnit.test("statusCode set to 301 and page changed to the correct page", function(){
+  F(".information").exists("component was loaded and rendered");
+
+  var state = this.state;
+  F(function(){
+    QUnit.equal(state.attr("statusCode"), 301, "Status code set to redirect");
+    QUnit.equal(state.attr("page"), "plugins", "Page was changed to the correct page");
+  });
+});
+
+QUnit.test("doesn't redirect when the page is correct", function(){
+  var state;
+  F(function(){
+    state = new State({
+      page: "components",
+      package: "bit-grid"
+    });
+    var template = stache("<component-page package-name='{package}'></component-page>");
+    $("#qunit-test-area").html(template(state));
+  });
+
+  F(".information").exists("component was loaded and rendered");
+
+  var state = this.state;
+  F(function(){
+    QUnit.equal(state.attr("statusCode"), undefined, "statusCode did not change");
+    QUnit.equal(state.attr("page"), "components", "page did not change");
+  });
 });

--- a/src/component/test.html
+++ b/src/component/test.html
@@ -1,3 +1,4 @@
 <title>&lt;component-page&gt;</title>
-<script src="../../node_modules/steal/steal.js" main="src/component/component_test"></script>
+<script src="../../node_modules/steal/steal.js" main="canrocks/component/component_test"></script>
 <div id="qunit-fixture"></div>
+<div id="qunit-test-area"></div>

--- a/src/index.stache
+++ b/src/index.stache
@@ -41,11 +41,11 @@
           <search-results search-term="{query}"></search-results>
         </can-import>
       {{/eq}}
-      {{#eq page "components"}}
+      {{#if isPluginPage}}
         <can-import from="canrocks/component/component.component!" can-tag="loading">
           <component-page package-name="{package}"></component-page>
         </can-import>
-      {{/eq}}
+      {{/if}}
       {{#eq page "how-to"}}
         <can-import from="canrocks/how-to/how-to.component!" can-tag="loading">
           <how-to></how-to>

--- a/src/list/list.component
+++ b/src/list/list.component
@@ -42,7 +42,7 @@
       <li class="component">
         <header>
           <hgroup>
-          <a can-href="{page='components', package=name}" class="component-name">
+          <a can-href="{page=typePlural, package=name}" class="component-name">
             <h1>{{name}}</h1>
           </a>
           <h4>{{primaryOwner}}</h4>

--- a/src/list/list_test.js
+++ b/src/list/list_test.js
@@ -1,5 +1,12 @@
 var QUnit = require('steal-qunit');
 var ViewModel = require('./list.component!').ViewModel;
+var F = require("funcunit");
+var $ = require("jquery");
+var can = require("can");
+var stache = require("can/view/stache/");
+var Component = require("canrocks/models/component").Component;
+
+F.attach(QUnit);
 
 // ViewModel unit tests
 QUnit.module('list');
@@ -7,4 +14,29 @@ QUnit.module('list');
 QUnit.skip('Has message', function(){
   var vm = new ViewModel();
   QUnit.equal(vm.attr('message'), 'This is the component-list component');
+});
+
+// Component tests
+QUnit.module("<component-list>", {
+  setup: function(){
+    this.dfd = new can.Deferred();
+    this.state = new can.Map({
+      promise: this.dfd.promise()
+    });
+    var template = stache("<component-list promise='{promise}'></component-list>");
+    $("#qunit-test-area").html(template(this.state));
+  },
+  teardown: function(){
+    $("#qunit-test-area").empty();
+  }
+});
+
+QUnit.test("It has the correct link according to the type of plugin", function(){
+  var components = new Component.List([
+    {type: "plugin"}
+  ]);
+
+  this.dfd.resolve(components);
+
+  F(".component-name").attr("href", /page=plugins/, "Correct link for the type of plugin");
 });

--- a/src/list/test.html
+++ b/src/list/test.html
@@ -1,3 +1,4 @@
 <title>list</title>
 <script src="../../node_modules/steal/steal.js" main="src/list/list_test"></script>
 <div id="qunit-fixture"></div>
+<div id="qunit-test-area"></div>

--- a/src/models/component.js
+++ b/src/models/component.js
@@ -15,6 +15,11 @@ var Component = exports.Component = can.Map.extend({
         this.attr("primaryOwner", val.attr(0));
         return val;
       }
+    },
+    typePlural: {
+      get: function(){
+        return (this.attr("type") || "plugin") + "s";
+      }
     }
   }
 });

--- a/src/test/app_test.js
+++ b/src/test/app_test.js
@@ -1,0 +1,29 @@
+var State = require("../app");
+var QUnit = require("steal-qunit");
+
+QUnit.module("canrocks/app");
+
+QUnit.test("It creates a 404 when an invalid page is set", function(){
+  var state = new State({
+    page: "foo-bar"
+  });
+
+  QUnit.equal(state.attr("statusCode"), 404, "Got a 404");
+});
+
+QUnit.test("components, plugins, attributes are all valid pages", function(){
+  var state = new State();
+
+  var expected = function(name){
+    QUnit.equal(state.attr("statusCode"), undefined, name + " is a valid page");
+  };
+
+  [
+    "components",
+    "plugins",
+    "attributes"
+  ].forEach(function(page){
+    state.attr("page", page);
+    expected(page);
+  });
+});

--- a/src/test/test.js
+++ b/src/test/test.js
@@ -3,3 +3,5 @@ require("steal-qunit");
 require("canrocks/models/test");
 require("canrocks/list/list_test");
 require("canrocks/search/search_test");
+require("canrocks/component/component_test");
+require("canrocks/test/app_test");


### PR DESCRIPTION
This sets the `page` to the correct value based on the type of plugin.
Also implements 301 redirects when something like
`/components/some-plugin` is requested.

Fixes #13