### PR TITLE
markdown-content should handle receiving no markdown

### DIFF
--- a/src/markdown/markdown.js
+++ b/src/markdown/markdown.js
@@ -20,6 +20,7 @@ exports.Component = Component.extend({
   helpers: {
     "2html": function(markdown){
       markdown = markdown.isComputed ? markdown() : markdown;
+      if(!markdown) return markdown;
       var html = marked(markdown);
       var frag = can.frag(html);
 

--- a/src/markdown/markdown_test.js
+++ b/src/markdown/markdown_test.js
@@ -1,10 +1,10 @@
-import QUnit from 'steal-qunit';
-import { ViewModel } from './markdown';
+var QUnit = require("steal-qunit");
+var ViewModel = require("./markdown").ViewModel;
+var stache = require("can/view/stache/");
 
-// ViewModel unit tests
-QUnit.module('markdown');
+QUnit.module("<markdown-content>");
 
-QUnit.test('Has message', function(){
-  var vm = new ViewModel();
-  QUnit.equal(vm.attr('message'), 'This is the markdown-content component');
+QUnit.test("can handle no markdown content", function(){
+  var template = stache("<markdown-content data='{md}'></markdown-content>");
+  ok(template(), "the template did not throw with undefined markdown");
 });

--- a/src/markdown/test.html
+++ b/src/markdown/test.html
@@ -1,3 +1,4 @@
-<title>markdown</title>
-<script src="../../node_modules/steal/steal.js" main="src/markdown/markdown_test"></script>
+<title>&lt;markdown-content&gt;</title>
+<script src="../../node_modules/steal/steal.js" main="canrocks/markdown/markdown_test"></script>
 <div id="qunit-fixture"></div>
+<div id="qunit-test-area"></div>

--- a/src/test/test.js
+++ b/src/test/test.js
@@ -4,4 +4,5 @@ require("canrocks/models/test");
 require("canrocks/list/list_test");
 require("canrocks/search/search_test");
 require("canrocks/component/component_test");
+require("canrocks/markdown/markdown_test");
 require("canrocks/test/app_test");


### PR DESCRIPTION
In the case where no markdown is received, simply return undefined from
the helper. marked will throw with no markdown. Fixes #16