### PR TITLE
Use cloudant npm package

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -8,15 +8,7 @@ var data = [{
 }];
 
 var crawl = require("./crawl").crawl;
-
-var cradle = require("cradle");
-var connection = new(cradle.Connection)('https://canjs.cloudant.com', 443, {
-  auth: {
-    username: process.env.COUCHUSER,
-    password: process.env.COUCHPASS
-  }
-});
-var db = connection.database("canjs");
+var db = require("./db");
 
 module.exports = function(app){
   app.get("/api/component/:name", function(req, res){
@@ -41,15 +33,25 @@ module.exports = function(app){
     var viewName;
     var params = { "include_docs": true };
 
+    var handleResponse = function(err, body){
+      if(err) return handleError(err);
+      var results = body.rows.map(function(i){
+        return i.doc;
+      });
+      res.send(results);
+    };
+
     if(query.type) {
-      viewName = "components/byType";
+      viewName = "byType";
       if(query.type === "recent") {
-        viewName = "components/byDate";
+        viewName = "byDate";
         params.descending = true;
       }
     } else if(query.query) {
-      viewName = "components/byQuery";
-      params.key = query.query.toLowerCase();
+      params.q = query.query.toLowerCase();
+
+      db.search("components", "pluginSearch", params, handleResponse);
+      return;
     } else {
       res.status(404).send("Unknown query parameter")
       return;
@@ -60,13 +62,7 @@ module.exports = function(app){
       params.limit = query.limit;
     }
 
-    db.view(viewName, params, function(err, docs){
-      if(err) return handleError(err);
-      var results = docs.map(function(i){
-        return i;
-      });
-      res.send(results);
-    });
+    db.view("components", viewName, params, handleResponse);
   });
 
   app.post("/api/component", function(req, res){

--- a/lib/crawl.js
+++ b/lib/crawl.js
@@ -7,15 +7,7 @@ if(!process.env.COUCHUSER || !process.env.COUCHPASS) {
   throw new Error("The environment variables COUCHUSER and COUCHPASS are required.");
 }
 
-var cradle = require("cradle");
-var connection = new(cradle.Connection)('https://canjs.cloudant.com', 443, {
-  auth: {
-    username: process.env.COUCHUSER,
-    password: process.env.COUCHPASS
-  }
-});
-
-var db = connection.database("canjs");
+var db = require("./db");
 
 var types = {
   component: [
@@ -54,7 +46,7 @@ var hasKeywords = function(keywords){
 
 var crawlAll = exports.crawlAll = function(){
   loadPromise.then(function(){
-    npm.commands.search("can-component", true, function(err, results){
+    npm.commands.search("canjs", true, function(err, results){
       for(var p in results) {
         var pkg = results[p];
         if(hasKeywords(pkg.keywords)) {
@@ -91,7 +83,7 @@ var crawl = exports.crawl = function(packageName, forceSave){
           pkg.readme = readme;
           pkg.type = getType(pkg.keywords);
 
-          db.save(pkg.name, pkg, function(err){
+          db.insert(pkg, pkg.name, function(err){
           });
         });
       }

--- a/lib/db.js
+++ b/lib/db.js
@@ -1,0 +1,8 @@
+var Cloudant = require("cloudant");
+var cloudant = new Cloudant({
+  account: process.env.COUCHUSER,
+  password: process.env.COUCHPASS
+});
+var db = cloudant.db.use("canjs");
+
+module.exports = db;

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
       "body-parser",
       "pdenodeify",
       "get-package-readme",
-      "cradle"
+      "cloudant"
     ],
     "envs": {
       "production": {
@@ -72,8 +72,8 @@
     "can": "^2.3.0-pre.8",
     "can-connect": "^0.2.7",
     "can-ssr": "^0.6.0",
+    "cloudant": "^1.3.0",
     "compression": "^1.5.2",
-    "cradle": "^0.6.9",
     "done-autorender": "^0.4.1",
     "done-component": "^0.2.0",
     "done-css": "^1.1.6",


### PR DESCRIPTION
This switches away from `cradle` and to use `cloudant` instead. Cloudant
has search functionality which is something we need, so it makes sense
to use their npm package. This will make #8 easier