### PR TITLE
Allow searches scoped to a type

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -9,6 +9,7 @@ var data = [{
 
 var crawl = require("./crawl").crawl;
 var db = require("./db");
+var createQuery = require("./search_query/search_query");
 
 module.exports = function(app){
   app.get("/api/component/:name", function(req, res){
@@ -48,7 +49,7 @@ module.exports = function(app){
         params.descending = true;
       }
     } else if(query.query) {
-      params.q = query.query.toLowerCase();
+      params.q = createQuery(query.query.toLowerCase());
 
       db.search("components", "pluginSearch", params, handleResponse);
       return;

--- a/lib/search_query/search_query.js
+++ b/lib/search_query/search_query.js
@@ -1,0 +1,20 @@
+module.exports = createQuery;
+
+var typeExp = /\+([a-zA-Z]+) ?/;
+
+function createQuery(searchString){
+  var types = [];
+  var ss = searchString.replace(typeExp, function(whole, part){
+    types.push("type:"+part);
+    return "";
+  });
+  if(types.length) {
+    ss = ss.trim();
+    // Handles the case of only searching for a type
+    if(ss) {
+      types.unshift(ss);
+    }
+    return types.join(" AND ");
+  }
+  return searchString;
+}

--- a/lib/search_query/search_query_test.js
+++ b/lib/search_query/search_query_test.js
@@ -1,0 +1,32 @@
+var test = require("tape");
+var createQuery = require("./search_query");
+
+test("basic query", function(t){
+  t.plan(1);
+  var query = createQuery("canjs stuff");
+  t.equal(query, "canjs stuff");
+});
+
+test("type in the back", function(t){
+  t.plan(1);
+  var query = createQuery("tabs +plugin");
+  t.equal(query, "tabs AND type:plugin");
+});
+
+test("type in the front", function(t){
+  t.plan(1);
+  var query = createQuery("+component tabs and stuff");
+  t.equal(query, "tabs and stuff AND type:component");
+});
+
+test("type in the middle", function(t){
+  t.plan(1);
+  var query = createQuery("something +attribute else");
+  t.equal(query, "something else AND type:attribute");
+});
+
+test("only searching for a type", function(t){
+  t.plan(1);
+  var query = createQuery("+component");
+  t.equal(query, "type:component");
+});

--- a/lib/test.js
+++ b/lib/test.js
@@ -1,0 +1,1 @@
+require("./search_query/search_query_test");

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "url": ""
   },
   "scripts": {
-    "test": "testee test.html --browsers firefox --reporter Spec",
+    "test:node": "node lib/test | tap-spec",
+    "test:browser": "testee test.html --browsers firefox --reporter Spec",
+    "test": "npm run test:node && npm run test:browser",
     "start": "node lib/main",
     "can-serve": "can-serve --port 8080",
     "live-reload": "steal-tools live-reload",
@@ -57,7 +59,9 @@
       "pdenodeify",
       "get-package-readme",
       "cloudant",
-      "heapdump"
+      "heapdump",
+      "tape",
+      "tap-spec"
     ],
     "envs": {
       "production": {
@@ -101,6 +105,8 @@
     "funcunit": "^3.0.0",
     "steal-qunit": "^0.1.1",
     "steal-tools": "^0.11.0-pre.9",
+    "tap-spec": "^4.1.0",
+    "tape": "^4.2.1",
     "testee": "^0.2.0"
   }
 }


### PR DESCRIPTION
This allows you to perform searches like `tabs +component` which will
limit searches to only that type. Likewise you can do `+plugin` to only
see plugins.

Closes #8