### PR TITLE
Implements the <usage-tips> component

### DIFF
--- a/src/home/home.component
+++ b/src/home/home.component
@@ -1,5 +1,6 @@
 <can-component tag="home-page">
   <template>
+    <can-import from="canrocks/usage-tips/usage-tips.component!" />
     <can-import from="canrocks/list/list.component!" />
     <can-import from="canrocks/models/component" />
     <can-import from="canrocks/search-form/search-form.component!" />
@@ -17,6 +18,10 @@
       </div>
       <div class="form-content">
         <search-form></search-form>
+      </div>
+
+      <div class="site-tip">
+        <usage-tips></usage-tips>
       </div>
 
       <div class="lists">
@@ -70,7 +75,7 @@
     }
     home-page .component-list-title {
       text-align: center;
-      margin-top: 4em;
+      margin-top: 2em;
     }
     home-page .lists {
       display: flex;
@@ -98,6 +103,15 @@
     home-page type-badge .badge {
       height: auto;
       border-top: none;
+    }
+
+    home-page .site-tip {
+      margin-top: 2em;
+    }
+
+    home-page usage-tips {
+      display: inline-block;
+      padding: 0 10em;
     }
   </style>
 </can-component>

--- a/src/test/test.js
+++ b/src/test/test.js
@@ -5,4 +5,5 @@ require("canrocks/list/list_test");
 require("canrocks/search/search_test");
 require("canrocks/component/component_test");
 require("canrocks/markdown/markdown_test");
+require("canrocks/usage-tips/usage-tips_test");
 require("canrocks/test/app_test");

--- a/src/usage-tips/test.html
+++ b/src/usage-tips/test.html
@@ -1,0 +1,4 @@
+<title>&lt;usage-tips&gt;</title>
+<script src="../../node_modules/steal/steal.js" main="canrocks/usage-tips/usage-tips_test"></script>
+<div id="qunit-fixture"></div>
+<div id="qunit-test-area"></div>

--- a/src/usage-tips/tips/type-search.stache
+++ b/src/usage-tips/tips/type-search.stache
@@ -1,0 +1,3 @@
+<can-import from="can/view/href/" />
+
+Limit a search to a type of plugin by including a <strong>+</strong> and the plugin type like: <a can-href="{page='search', query='tabs +component'}">tabs +component</a> to search only for components. Types are: <a can-href="{page='search', query='+component'}">component</a>, <a can-href="{page='search', query='+attribute'}">attribute</a>, and <a can-href="{page='search', query='+plugin'}">plugin</a>.

--- a/src/usage-tips/usage-tips.component
+++ b/src/usage-tips/usage-tips.component
@@ -1,0 +1,39 @@
+<can-component tag="usage-tips">
+  <style>
+    usage-tips {
+      display: inline;
+      text-align: center;
+      font-size: 90%;
+    }
+  </style>
+  <template>
+    {{chosenTip}}
+  </template>
+  <script type="view-model">
+    var tips = [
+      require("canrocks/usage-tips/tips/type-search.stache!")
+    ];
+
+    var Map = require("can/map/");
+    require("can/map/define/");
+
+    module.exports = Map.extend({
+      define: {
+        tipNumber: {
+          type: "number",
+          // random by default.
+          value: function() {
+            return Math.floor(Math.random()*tips.length);
+          }
+        },
+        chosenTip: {
+          get: function(){
+            var tmpl = tips[this.attr("tipNumber")];
+            var root = this.attr("@root");
+            return tmpl(root);
+          }
+        }
+      }
+    });
+  </script>
+</can-component>

--- a/src/usage-tips/usage-tips.html
+++ b/src/usage-tips/usage-tips.html
@@ -1,0 +1,7 @@
+<script type="text/stache" can-autorender>
+  <can-import from="can/route/" />
+  <can-import from="canrocks/usage-tips/usage-tips.component!" />
+  <usage-tips></usage-tips>
+</script>
+<script src="../../node_modules/steal/steal.js"
+        main="can/view/autorender/"></script>

--- a/src/usage-tips/usage-tips.md
+++ b/src/usage-tips/usage-tips.md
@@ -1,0 +1,8 @@
+@parent canrocks
+@module {can.Component} canrocks/usage-tips <usage-tips>
+@signature `<usage-tips>`
+
+@body
+
+## <usage-tips>
+

--- a/src/usage-tips/usage-tips_test.js
+++ b/src/usage-tips/usage-tips_test.js
@@ -1,0 +1,21 @@
+var QUnit = require("steal-qunit");
+var ViewModel = require("./usage-tips.component!").ViewModel;
+var $ = require("jquery");
+var F = require("funcunit");
+var stache = require("can/view/stache/");
+require("can/route/");
+
+F.attach(QUnit);
+
+// ViewModel unit tests
+QUnit.module("<usage-tips>", {
+  setup: function(){
+    var renderer = stache("<usage-tips tip-number='0'></usage-tips>");
+    $("#qunit-test-area").html(renderer());
+  }
+});
+
+QUnit.test("Uses the tip number passed in from attributes", function(){
+  F("usage-tips").text(/Limit a search/, "The type search tip was shown first");
+});
+


### PR DESCRIPTION
The usage-tips component is available on the home page and displays a
tip for using the site. Currently there is only one tip that explains
how to limit a search by type.

Fixes #9