### PR TITLE
Adjust the production cdn baseURL

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     ],
     "envs": {
       "production": {
-        "baseURL": "http://canrocks.s3-website-us-east-1.amazonaws.com/dist/"
+        "baseURL": "http://canrocks.s3-website-us-east-1.amazonaws.com/"
       }
     }
   },

--- a/src/index.stache
+++ b/src/index.stache
@@ -66,7 +66,7 @@
 
     {{#switch @env.NODE_ENV}}
       {{#case "production"}}
-        <script src="http://canrocks.s3-website-us-east-1.amazonaws.com/dist/node_modules/steal/steal.production.js"  main="canrocks/index.stache!done-autorender"></script>
+        <script src="http://canrocks.s3-website-us-east-1.amazonaws.com/node_modules/steal/steal.production.js"  main="canrocks/index.stache!done-autorender"></script>
       {{/case}}
       {{#case "staging"}}
         <script src="/node_modules/steal/steal.production.js" main="canrocks/index.stache!done-autorender"></script>


### PR DESCRIPTION
Probably because of an old bug in donejs-deploy we were using dist/ as
the baseURL when it should just be / (from the cdn url).  I believe the
reason this was happening was the previous version of donejs-deploy had
a bug that has been resolved. I'm going to clean out the dist/ folder on
the CDN which should no longer be needed.