### PR TITLE
Fix registration

### DIFF
--- a/lib/crawl.js
+++ b/lib/crawl.js
@@ -86,9 +86,12 @@ var crawl = exports.crawl = function(packageName, forceSave){
           pkg.type = getType(pkg.keywords);
 
           db.head(pkg.name, function(err, _, headers) {
-            if(err) return;
+            if(err && err.statusCode !== 404) {
+              return;
+            }
 
-            pkg._rev = headers["etag"].slice(1, -1);
+            if(!err)
+              pkg._rev = headers["etag"].slice(1, -1);
             db.insert(pkg, pkg.name, function(err){});
           });
         });


### PR DESCRIPTION
Registration was broken because we did a HEAD against the package name
to get the `_rev` and existing if we got an error. The result was that
any component not already in the database flat out doesn't work. This
fixes it by checking for 404s.